### PR TITLE
Add Polylang Pro compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Integrates the **Ultimate Member** plugin with the **Polylang** plugin. Makes Ul
 
 __Note:__ This plugin requires the [Ultimate Member](https://wordpress.org/plugins/ultimate-member/) and [Polylang](https://wordpress.org/plugins/polylang/) plugins to be installed first.
 
-__Note:__ This plugin is designed to integrate with the "Polylang" plugin, do not use it with the "Polylang PRO" plugin.
+__Note:__ This plugin integrates with both the "Polylang" and "Polylang Pro" plugins.
 
 ### How to install from GitHub
 

--- a/assets/css/um-polylang-admin.css
+++ b/assets/css/um-polylang-admin.css
@@ -1,7 +1,7 @@
 /*
  Plugin Name: Ultimate Member - Polylang
  Description: This styles are used in the wp-admin area
- Version: 1.2.2
+ Version: 1.2.3
 */
 
 /* Fix column width in the "Forms" table */

--- a/includes/class-um-polylang.php
+++ b/includes/class-um-polylang.php
@@ -280,6 +280,23 @@ class UM_Polylang {
 
 
         /**
+         * Override the cached request language for the current request.
+         *
+         * @since 1.2.3
+         *
+         * @param string $language Language slug to store.
+         */
+        public function set_request_language( $language ) {
+                if ( empty( $language ) || 'all' === $language ) {
+                        $this->request_language = '';
+                        return;
+                }
+
+                $this->request_language = sanitize_key( $language );
+        }
+
+
+        /**
          * Try to determine the current language from the referring URL.
          *
          * @since 1.2.3

--- a/includes/class-um-polylang.php
+++ b/includes/class-um-polylang.php
@@ -164,10 +164,14 @@ class UM_Polylang {
                         }
                 }
 
-                if ( empty( $lang ) || 'all' === $lang ) {
-                        $locale = determine_locale();
-                        $lang   = substr( $locale, 0, 2 );
-                }
+               if ( empty( $lang ) || 'all' === $lang ) {
+                       $lang = pll_default_language();
+               }
+
+               if ( empty( $lang ) || 'all' === $lang ) {
+                       $locale = determine_locale();
+                       $lang   = substr( $locale, 0, 2 );
+               }
                 $language = PLL()->model->get_language( $lang );
 
                 return is_object( $language ) ? $language->get_prop( $field ) : $lang;

--- a/includes/class-um-polylang.php
+++ b/includes/class-um-polylang.php
@@ -150,19 +150,19 @@ class UM_Polylang {
                         $lang = sanitize_key( $_GET['lang'] );
                 }
 
-                if ( empty( $lang ) || 'all' === $lang ) {
-                        $referer_lang = $this->detect_language_from_referer();
-                        if ( $referer_lang ) {
-                                $lang = $referer_lang;
-                        }
-                }
+               if ( empty( $lang ) || 'all' === $lang ) {
+                       $request_lang = $this->detect_language_from_request();
+                       if ( $request_lang ) {
+                               $lang = $request_lang;
+                       }
+               }
 
-                if ( empty( $lang ) || 'all' === $lang ) {
-                        $request_lang = $this->detect_language_from_request();
-                        if ( $request_lang ) {
-                                $lang = $request_lang;
-                        }
-                }
+               if ( empty( $lang ) || 'all' === $lang ) {
+                       $referer_lang = $this->detect_language_from_referer();
+                       if ( $referer_lang ) {
+                               $lang = $referer_lang;
+                       }
+               }
 
                if ( empty( $lang ) || 'all' === $lang ) {
                        $lang = pll_default_language();

--- a/includes/class-um-polylang.php
+++ b/includes/class-um-polylang.php
@@ -231,9 +231,13 @@ class UM_Polylang {
 	 *
 	 * @return boolean
 	 */
-	public function is_active() {
-		return defined( 'POLYLANG_VERSION' ) && function_exists( 'PLL' );
-	}
+        public function is_active() {
+                if ( function_exists( 'um_polylang_is_polylang_active' ) ) {
+                        return um_polylang_is_polylang_active();
+                }
+
+                return function_exists( 'PLL' ) && ( defined( 'POLYLANG_VERSION' ) || defined( 'POLYLANG_PRO_VERSION' ) );
+        }
 
 
 	/**

--- a/includes/class-um-polylang.php
+++ b/includes/class-um-polylang.php
@@ -10,6 +10,15 @@ defined( 'ABSPATH' ) || exit;
  */
 class UM_Polylang {
 
+	/**
+	 * Cached request language for the current page load.
+	 *
+	 * @since 1.2.3
+	 *
+	 * @var string|null
+	 */
+	protected $request_language = null;
+
 
 	/**
 	 * An instance of the class.
@@ -36,6 +45,8 @@ class UM_Polylang {
 	 * Class constructor.
 	 */
 	public function __construct() {
+
+                add_action( 'wp', array( $this, 'prime_request_language' ), 1 );
 
 		$this->core();
 		if ( UM()->is_request( 'admin' ) ) {
@@ -152,7 +163,7 @@ class UM_Polylang {
                 }
 
                 if ( empty( $lang ) || 'all' === $lang ) {
-                        $request_lang = $this->detect_language_from_request();
+                        $request_lang = $this->get_request_language();
 
                         if ( $request_lang ) {
                                 $lang = $request_lang;
@@ -197,6 +208,78 @@ class UM_Polylang {
 
 
         /**
+         * Determine and cache the current request language once the main query is available.
+         *
+         * @since 1.2.3
+         */
+        public function prime_request_language() {
+                if ( null !== $this->request_language && '' !== $this->request_language ) {
+                        return;
+                }
+
+                $language = '';
+
+                if ( function_exists( 'get_queried_object_id' ) ) {
+                        $post_id = get_queried_object_id();
+
+                        if ( $post_id ) {
+                                $language = pll_get_post_language( $post_id, 'slug' );
+                        }
+                }
+
+                if ( empty( $language ) ) {
+                        global $post;
+
+                        if ( $post instanceof \WP_Post ) {
+                                $language = pll_get_post_language( $post->ID, 'slug' );
+                        }
+                }
+
+                if ( empty( $language ) ) {
+                        $language = $this->detect_language_from_request();
+                }
+
+                if ( empty( $language ) ) {
+                        $language = pll_current_language();
+                }
+
+                if ( empty( $language ) || 'all' === $language ) {
+                        $language = '';
+                }
+
+                $this->request_language = $language;
+
+                if ( $language ) {
+                        $permalinks = UM()->Polylang()->core()->permalinks();
+
+                        if ( method_exists( $permalinks, 'sync_current_language_permalinks' ) ) {
+                                $permalinks->sync_current_language_permalinks( $language );
+                        }
+                }
+        }
+
+
+        /**
+         * Return the detected language for the current request.
+         *
+         * @since 1.2.3
+         *
+         * @return string Language slug when detected, otherwise an empty string.
+         */
+        public function get_request_language() {
+                if ( null === $this->request_language ) {
+                        $this->request_language = $this->detect_language_from_request();
+
+                        if ( empty( $this->request_language ) || 'all' === $this->request_language ) {
+                                $this->request_language = '';
+                        }
+                }
+
+                return $this->request_language ? $this->request_language : '';
+        }
+
+
+        /**
          * Try to determine the current language from the referring URL.
          *
          * @since 1.2.3
@@ -224,26 +307,46 @@ class UM_Polylang {
          * @return string Language slug if detected, otherwise an empty string.
          */
         protected function detect_language_from_request() {
+                $language = '';
+
                 if ( function_exists( 'get_queried_object_id' ) ) {
                         $post_id = get_queried_object_id();
                         if ( $post_id ) {
                                 $language = pll_get_post_language( $post_id, 'slug' );
+
                                 if ( $language ) {
                                         return $language;
                                 }
                         }
                 }
 
+                global $post;
+
+                if ( $post instanceof \WP_Post ) {
+                        $language = pll_get_post_language( $post->ID, 'slug' );
+
+                        if ( $language ) {
+                                return $language;
+                        }
+                }
+
                 $request_uri = isset( $_SERVER['REQUEST_URI'] ) ? wp_unslash( $_SERVER['REQUEST_URI'] ) : '';
+
                 if ( empty( $request_uri ) ) {
-                        return '';
+                        return pll_default_language();
                 }
 
                 $request_uri = strtok( $request_uri, '#' );
 
                 $url = home_url( $request_uri );
 
-                return $this->detect_language_from_url( $url );
+                $language = $this->detect_language_from_url( $url );
+
+                if ( empty( $language ) ) {
+                        $language = pll_default_language();
+                }
+
+                return $language;
         }
 
 
@@ -378,7 +481,20 @@ class UM_Polylang {
          * @return boolean
          */
         public function is_default() {
-                return $this->get_current() === $this->get_default();
+                $default = $this->get_default();
+                $request = $this->get_request_language();
+
+                if ( $request ) {
+                        return $request === $default;
+                }
+
+                $current = $this->get_current();
+
+                if ( $current ) {
+                        return $current === $default;
+                }
+
+                return true;
         }
 
         /**

--- a/includes/class-um-polylang.php
+++ b/includes/class-um-polylang.php
@@ -170,9 +170,9 @@ class UM_Polylang {
                         }
                 }
 
-                if ( empty( $lang ) || 'all' === $lang ) {
-                        $lang = pll_current_language();
-                } else {
+               if ( empty( $lang ) || 'all' === $lang ) {
+                       $lang = pll_current_language();
+               } else {
                         $current_lang = pll_current_language();
 
                         if ( $current_lang && $current_lang !== $lang ) {
@@ -186,16 +186,16 @@ class UM_Polylang {
                         }
                 }
 
-                if ( empty( $lang ) || 'all' === $lang ) {
-                        $lang = pll_default_language();
-                }
+               if ( empty( $lang ) || 'all' === $lang ) {
+                       $referer_lang = $this->detect_language_from_referer();
+                       if ( $referer_lang ) {
+                               $lang = $referer_lang;
+                       }
+               }
 
-                if ( empty( $lang ) || 'all' === $lang ) {
-                        $referer_lang = $this->detect_language_from_referer();
-                        if ( $referer_lang ) {
-                                $lang = $referer_lang;
-                        }
-                }
+               if ( empty( $lang ) || 'all' === $lang ) {
+                       $lang = pll_default_language();
+               }
 
                 if ( empty( $lang ) || 'all' === $lang ) {
                         $locale = determine_locale();

--- a/includes/class-um-polylang.php
+++ b/includes/class-um-polylang.php
@@ -158,6 +158,13 @@ class UM_Polylang {
                 }
 
                 if ( empty( $lang ) || 'all' === $lang ) {
+                        $request_lang = $this->detect_language_from_request();
+                        if ( $request_lang ) {
+                                $lang = $request_lang;
+                        }
+                }
+
+                if ( empty( $lang ) || 'all' === $lang ) {
                         $locale = determine_locale();
                         $lang   = substr( $locale, 0, 2 );
                 }
@@ -183,13 +190,57 @@ class UM_Polylang {
                         $referer = wp_unslash( $_SERVER['HTTP_REFERER'] );
                 }
 
-                if ( empty( $referer ) ) {
+                return $this->detect_language_from_url( $referer );
+        }
+
+
+        /**
+         * Try to determine the current language from the current request.
+         *
+         * @since 1.2.3
+         *
+         * @return string Language slug if detected, otherwise an empty string.
+         */
+        protected function detect_language_from_request() {
+                if ( function_exists( 'get_queried_object_id' ) ) {
+                        $post_id = get_queried_object_id();
+                        if ( $post_id ) {
+                                $language = pll_get_post_language( $post_id, 'slug' );
+                                if ( $language ) {
+                                        return $language;
+                                }
+                        }
+                }
+
+                $request_uri = isset( $_SERVER['REQUEST_URI'] ) ? wp_unslash( $_SERVER['REQUEST_URI'] ) : '';
+                if ( empty( $request_uri ) ) {
                         return '';
                 }
 
-                $referer = esc_url_raw( $referer );
+                $request_uri = strtok( $request_uri, '#' );
 
-                $post_id = url_to_postid( $referer );
+                $url = home_url( $request_uri );
+
+                return $this->detect_language_from_url( $url );
+        }
+
+
+        /**
+         * Extract the language from a provided URL.
+         *
+         * @since 1.2.3
+         *
+         * @param string $url URL to inspect.
+         * @return string Language slug if detected, otherwise an empty string.
+         */
+        protected function detect_language_from_url( $url ) {
+                if ( empty( $url ) ) {
+                        return '';
+                }
+
+                $url = esc_url_raw( $url );
+
+                $post_id = url_to_postid( $url );
                 if ( $post_id ) {
                         $language = pll_get_post_language( $post_id, 'slug' );
                         if ( $language ) {
@@ -197,7 +248,7 @@ class UM_Polylang {
                         }
                 }
 
-                $path = wp_parse_url( $referer, PHP_URL_PATH );
+                $path = wp_parse_url( $url, PHP_URL_PATH );
                 if ( empty( $path ) ) {
                         return '';
                 }

--- a/includes/class-um-polylang.php
+++ b/includes/class-um-polylang.php
@@ -145,18 +145,75 @@ class UM_Polylang {
 	 */
 	public function get_current( $field = 'slug' ) {
 
-		$lang = pll_current_language();
-		if ( isset( $_GET['lang'] ) ) {
-			$lang = sanitize_key( $_GET['lang'] );
-		}
-		if ( empty( $lang ) || 'all' === $lang ) {
-			$locale = determine_locale();
-			$lang   = substr( $locale, 0, 2 );
-		}
-		$language = PLL()->model->get_language( $lang );
+                $lang = pll_current_language();
+                if ( isset( $_GET['lang'] ) ) {
+                        $lang = sanitize_key( $_GET['lang'] );
+                }
 
-		return is_object( $language ) ? $language->get_prop( $field ) : $lang;
-	}
+                if ( empty( $lang ) || 'all' === $lang ) {
+                        $referer_lang = $this->detect_language_from_referer();
+                        if ( $referer_lang ) {
+                                $lang = $referer_lang;
+                        }
+                }
+
+                if ( empty( $lang ) || 'all' === $lang ) {
+                        $locale = determine_locale();
+                        $lang   = substr( $locale, 0, 2 );
+                }
+                $language = PLL()->model->get_language( $lang );
+
+                return is_object( $language ) ? $language->get_prop( $field ) : $lang;
+        }
+
+
+        /**
+         * Try to determine the current language from the referring URL.
+         *
+         * @since 1.2.3
+         *
+         * @return string Language slug if detected, otherwise an empty string.
+         */
+        protected function detect_language_from_referer() {
+                $referer = '';
+
+                if ( isset( $_REQUEST['_wp_http_referer'] ) ) {
+                        $referer = wp_unslash( $_REQUEST['_wp_http_referer'] );
+                } elseif ( isset( $_SERVER['HTTP_REFERER'] ) ) {
+                        $referer = wp_unslash( $_SERVER['HTTP_REFERER'] );
+                }
+
+                if ( empty( $referer ) ) {
+                        return '';
+                }
+
+                $referer = esc_url_raw( $referer );
+
+                $post_id = url_to_postid( $referer );
+                if ( $post_id ) {
+                        $language = pll_get_post_language( $post_id, 'slug' );
+                        if ( $language ) {
+                                return $language;
+                        }
+                }
+
+                $path = wp_parse_url( $referer, PHP_URL_PATH );
+                if ( empty( $path ) ) {
+                        return '';
+                }
+
+                $segments  = array_filter( explode( '/', trim( $path, '/' ) ) );
+                $languages = pll_languages_list();
+
+                foreach ( $segments as $segment ) {
+                        $segment = sanitize_key( $segment );
+                        if ( in_array( $segment, $languages, true ) ) {
+                                return $segment;
+                        }
+                }
+
+                return '';
+        }
 
 
 	/**

--- a/includes/class-um-polylang.php
+++ b/includes/class-um-polylang.php
@@ -145,33 +145,51 @@ class UM_Polylang {
 	 */
 	public function get_current( $field = 'slug' ) {
 
-                $lang = pll_current_language();
+                $lang = '';
+
                 if ( isset( $_GET['lang'] ) ) {
                         $lang = sanitize_key( $_GET['lang'] );
                 }
 
-               if ( empty( $lang ) || 'all' === $lang ) {
-                       $request_lang = $this->detect_language_from_request();
-                       if ( $request_lang ) {
-                               $lang = $request_lang;
-                       }
-               }
+                if ( empty( $lang ) || 'all' === $lang ) {
+                        $request_lang = $this->detect_language_from_request();
 
-               if ( empty( $lang ) || 'all' === $lang ) {
-                       $lang = pll_default_language();
-               }
+                        if ( $request_lang ) {
+                                $lang = $request_lang;
+                        }
+                }
 
-               if ( empty( $lang ) || 'all' === $lang ) {
-                       $referer_lang = $this->detect_language_from_referer();
-                       if ( $referer_lang ) {
-                               $lang = $referer_lang;
-                       }
-               }
+                if ( empty( $lang ) || 'all' === $lang ) {
+                        $lang = pll_current_language();
+                } else {
+                        $current_lang = pll_current_language();
 
-               if ( empty( $lang ) || 'all' === $lang ) {
-                       $locale = determine_locale();
-                       $lang   = substr( $locale, 0, 2 );
-               }
+                        if ( $current_lang && $current_lang !== $lang ) {
+                                $this->log_debug(
+                                        'Override Polylang current language with request language.',
+                                        array(
+                                                'polylang' => $current_lang,
+                                                'request'  => $lang,
+                                        )
+                                );
+                        }
+                }
+
+                if ( empty( $lang ) || 'all' === $lang ) {
+                        $lang = pll_default_language();
+                }
+
+                if ( empty( $lang ) || 'all' === $lang ) {
+                        $referer_lang = $this->detect_language_from_referer();
+                        if ( $referer_lang ) {
+                                $lang = $referer_lang;
+                        }
+                }
+
+                if ( empty( $lang ) || 'all' === $lang ) {
+                        $locale = determine_locale();
+                        $lang   = substr( $locale, 0, 2 );
+                }
                 $language = PLL()->model->get_language( $lang );
 
                 return is_object( $language ) ? $language->get_prop( $field ) : $lang;

--- a/includes/class-um-polylang.php
+++ b/includes/class-um-polylang.php
@@ -158,14 +158,14 @@ class UM_Polylang {
                }
 
                if ( empty( $lang ) || 'all' === $lang ) {
+                       $lang = pll_default_language();
+               }
+
+               if ( empty( $lang ) || 'all' === $lang ) {
                        $referer_lang = $this->detect_language_from_referer();
                        if ( $referer_lang ) {
                                $lang = $referer_lang;
                        }
-               }
-
-               if ( empty( $lang ) || 'all' === $lang ) {
-                       $lang = pll_default_language();
                }
 
                if ( empty( $lang ) || 'all' === $lang ) {

--- a/includes/class-um-polylang.php
+++ b/includes/class-um-polylang.php
@@ -482,16 +482,16 @@ class UM_Polylang {
          */
         public function is_default() {
                 $default = $this->get_default();
-                $request = $this->get_request_language();
-
-                if ( $request ) {
-                        return $request === $default;
-                }
-
                 $current = $this->get_current();
 
                 if ( $current ) {
                         return $current === $default;
+                }
+
+                $request = $this->get_request_language();
+
+                if ( $request ) {
+                        return $request === $default;
                 }
 
                 return true;

--- a/includes/class-um-polylang.php
+++ b/includes/class-um-polylang.php
@@ -348,15 +348,37 @@ class UM_Polylang {
         }
 
 
-	/**
-	 * Check if the default language is chosen.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @return boolean
-	 */
-	public function is_default() {
-		return $this->get_current() === $this->get_default();
-	}
+        /**
+         * Check if the default language is chosen.
+         *
+         * @since 1.0.0
+         *
+         * @return boolean
+         */
+        public function is_default() {
+                return $this->get_current() === $this->get_default();
+        }
+
+        /**
+         * Log debugging information when debugging is enabled.
+         *
+         * @since 1.2.3
+         *
+         * @param string $message Debug message.
+         * @param array  $context Additional context to include in the log entry.
+         */
+        public function log_debug( $message, array $context = array() ) {
+                $enabled = apply_filters( 'um_polylang_enable_debug', defined( 'WP_DEBUG' ) && WP_DEBUG );
+
+                if ( ! $enabled ) {
+                        return;
+                }
+
+                if ( ! empty( $context ) ) {
+                        $message .= ' ' . wp_json_encode( $context );
+                }
+
+                error_log( '[UM Polylang] ' . $message );
+        }
 
 }

--- a/includes/core/class-mail.php
+++ b/includes/core/class-mail.php
@@ -110,10 +110,28 @@ class Mail {
 	 * @param array  $args     Arguments for sending email.
 	 */
 	public function set_user_lang( $email, $template, $args ) {
-		$user = get_user_by( 'email', $email );
-		if ( $user && ! empty( $user->locale ) ) {
-			$_GET['lang'] = substr( $user->locale, 0, 2 );
-		}
-	}
+               $language = '';
+
+               $user = get_user_by( 'email', $email );
+               if ( $user && ! empty( $user->locale ) ) {
+                       $language = substr( $user->locale, 0, 2 );
+               }
+
+               if ( empty( $language ) || 'all' === $language ) {
+                       $language = UM()->Polylang()->get_request_language();
+               }
+
+               if ( empty( $language ) || 'all' === $language ) {
+                       $language = UM()->Polylang()->get_current();
+               }
+
+               if ( empty( $language ) || 'all' === $language ) {
+                       $language = UM()->Polylang()->get_default();
+               }
+
+               if ( ! empty( $language ) && 'all' !== $language ) {
+                       $_GET['lang'] = $language;
+               }
+        }
 
 }

--- a/includes/core/class-mail.php
+++ b/includes/core/class-mail.php
@@ -110,15 +110,14 @@ class Mail {
 	 * @param array  $args     Arguments for sending email.
 	 */
 	public function set_user_lang( $email, $template, $args ) {
-               $language = '';
-
-               $user = get_user_by( 'email', $email );
-               if ( $user && ! empty( $user->locale ) ) {
-                       $language = substr( $user->locale, 0, 2 );
-               }
+               $language = UM()->Polylang()->get_request_language();
 
                if ( empty( $language ) || 'all' === $language ) {
-                       $language = UM()->Polylang()->get_request_language();
+                       $user = get_user_by( 'email', $email );
+
+                       if ( $user && ! empty( $user->locale ) ) {
+                               $language = substr( $user->locale, 0, 2 );
+                       }
                }
 
                if ( empty( $language ) || 'all' === $language ) {
@@ -130,6 +129,9 @@ class Mail {
                }
 
                if ( ! empty( $language ) && 'all' !== $language ) {
+                       $language = sanitize_key( $language );
+
+                       UM()->Polylang()->set_request_language( $language );
                        $_GET['lang'] = $language;
                }
         }

--- a/includes/core/class-permalinks.php
+++ b/includes/core/class-permalinks.php
@@ -265,7 +265,7 @@ class Permalinks {
 	public function localize_core_page_link( $link, $post_id ) {
 		if ( is_array( UM()->config()->permalinks ) && in_array( $post_id, UM()->config()->permalinks, true ) && ! $this->is_switcher && ! UM()->Polylang()->is_default() ) {
 			$url  = $this->get_page_url_for_language( $post_id, UM()->Polylang()->get_current() );
-			$link = ( $link !== $url ) ? $url : add_query_arg( 'lang', pll_current_language(), $url );
+                        $link = ( $link !== $url ) ? $url : add_query_arg( 'lang', UM()->Polylang()->get_current(), $url );
 		}
 		return $link;
 	}

--- a/includes/core/class-permalinks.php
+++ b/includes/core/class-permalinks.php
@@ -477,15 +477,13 @@ class Permalinks {
          * @since 1.2.3
          */
         public function sync_current_language_permalinks() {
-                if ( UM()->Polylang()->is_default() ) {
-                        return;
-                }
-
                 $language = UM()->Polylang()->get_current();
 
                 if ( empty( $language ) || $language === $this->synced_language ) {
                         return;
                 }
+
+                $default_language = UM()->Polylang()->get_default();
 
                 if ( empty( UM()->config()->permalinks ) || ! is_array( UM()->config()->permalinks ) ) {
                         return;
@@ -498,19 +496,30 @@ class Permalinks {
                                 continue;
                         }
 
-                        $translated_id = (int) pll_get_post( $page_id, $language );
+                        $default_page_id = (int) pll_get_post( $page_id, $default_language );
 
-                        if ( ! $translated_id ) {
-                                UM()->Polylang()->log_debug(
-                                        'Missing translation for Ultimate Member core page.',
-                                        array(
-                                                'language' => $language,
-                                                'slug'     => $slug,
-                                                'page_id'  => $page_id,
-                                        )
-                                );
+                        if ( ! $default_page_id ) {
+                                $default_page_id = $page_id;
+                        }
 
-                                continue;
+                        if ( $language === $default_language ) {
+                                $translated_id = $default_page_id;
+                        } else {
+                                $translated_id = (int) pll_get_post( $default_page_id, $language );
+
+                                if ( ! $translated_id ) {
+                                        UM()->Polylang()->log_debug(
+                                                'Missing translation for Ultimate Member core page.',
+                                                array(
+                                                        'language'         => $language,
+                                                        'slug'             => $slug,
+                                                        'default_page_id'  => $default_page_id,
+                                                        'stored_page_id'   => $page_id,
+                                                )
+                                        );
+
+                                        continue;
+                                }
                         }
 
                         $this->set_core_page_id( $slug, $translated_id );
@@ -520,7 +529,7 @@ class Permalinks {
                                 array(
                                         'language'      => $language,
                                         'slug'          => $slug,
-                                        'default_page'  => $page_id,
+                                        'default_page'  => $default_page_id,
                                         'translated_id' => $translated_id,
                                 )
                         );

--- a/includes/core/class-permalinks.php
+++ b/includes/core/class-permalinks.php
@@ -385,9 +385,33 @@ class Permalinks {
 
                         $url = $this->get_page_url_for_language( $page_id, UM()->Polylang()->get_current() );
 
-                        if ( $updated ) {
-                                $url = add_query_arg( 'updated', esc_attr( $updated ), $url );
+                        if ( empty( $updated ) && ! is_numeric( $updated ) ) {
+                                return $url;
                         }
+
+                        if ( is_array( $updated ) ) {
+                                $query_args = array();
+
+                                foreach ( $updated as $key => $value ) {
+                                        $key = sanitize_key( $key );
+
+                                        if ( '' === $key ) {
+                                                continue;
+                                        }
+
+                                        if ( is_scalar( $value ) ) {
+                                                $query_args[ $key ] = sanitize_text_field( wp_unslash( (string) $value ) );
+                                        }
+                                }
+
+                                if ( ! empty( $query_args ) ) {
+                                        $url = add_query_arg( $query_args, $url );
+                                }
+
+                                return $url;
+                        }
+
+                        $url = add_query_arg( 'updated', sanitize_text_field( wp_unslash( (string) $updated ) ), $url );
                 }
 
                 return $url;

--- a/includes/core/class-permalinks.php
+++ b/includes/core/class-permalinks.php
@@ -25,8 +25,11 @@ class Permalinks {
 		// Add rewrite rules for the Account and User page.
 		add_filter( 'rewrite_rules_array', array( &$this, 'add_rewrite_rules' ), 10, 1 );
 
-		// Links in emails.
-		add_action( 'um_before_email_notification_sending', array( $this, 'before_email' ) );
+                // Treat translated Ultimate Member core pages as real core pages.
+                add_filter( 'um_is_core_page', array( $this, 'maybe_recognize_translated_core_page' ), 10, 3 );
+
+                // Links in emails.
+                add_action( 'um_before_email_notification_sending', array( $this, 'before_email' ) );
 
 		// Pages.
 		add_filter( 'um_get_core_page_filter', array( &$this, 'localize_core_page_url' ), 10, 3 );
@@ -137,12 +140,55 @@ class Permalinks {
 
 		// Localize {password_reset_link}.
 		add_filter( 'um_get_core_page_filter', array( $this, 'localize_reset_url' ), 10, 3 );
-	}
+        }
 
 
-	/**
-	 * Filter links in the language switcher.
-	 *
+        /**
+         * Make sure Ultimate Member recognises translated core pages as core pages.
+         *
+         * @hooked um_is_core_page
+         *
+         * @since 1.2.3
+         *
+         * @param bool        $is_core Whether Ultimate Member already considers the page a core page.
+         * @param string      $slug    The core page slug (login, register, reset_password, etc.).
+         * @param int|string  $page_id Optional page ID Ultimate Member is checking against.
+         * @return bool
+         */
+        public function maybe_recognize_translated_core_page( $is_core, $slug, $page_id = 0 ) {
+                if ( $is_core || UM()->Polylang()->is_default() ) {
+                        return $is_core;
+                }
+
+                if ( empty( $slug ) || empty( UM()->config()->permalinks[ $slug ] ) ) {
+                        return $is_core;
+                }
+
+                $default_page_id = (int) UM()->config()->permalinks[ $slug ];
+                $language        = UM()->Polylang()->get_current();
+                $translated_id   = (int) pll_get_post( $default_page_id, $language );
+
+                if ( ! $translated_id ) {
+                        return $is_core;
+                }
+
+                if ( empty( $page_id ) ) {
+                        $page_id = get_queried_object_id();
+                }
+
+                if ( (int) $page_id !== $translated_id ) {
+                        return $is_core;
+                }
+
+                UM()->config()->permalinks[ $slug ] = $translated_id;
+
+                return true;
+        }
+
+
+        /**
+         * Filter links in the language switcher.
+         *
 	 * @since   1.0.1
 	 * @version 1.1.0 static method `update_core_pages` removed.
 	 *

--- a/includes/core/class-permalinks.php
+++ b/includes/core/class-permalinks.php
@@ -168,7 +168,7 @@ class Permalinks {
          * @return bool
          */
         public function maybe_recognize_translated_core_page( $is_core, $slug, $page_id = 0 ) {
-                if ( $is_core || UM()->Polylang()->is_default() ) {
+                if ( $is_core ) {
                         return $is_core;
                 }
 
@@ -176,15 +176,39 @@ class Permalinks {
                         return $is_core;
                 }
 
-                $this->sync_current_language_permalinks();
+                $language = '';
+
+                if ( $page_id ) {
+                        $language = pll_get_post_language( (int) $page_id, 'slug' );
+                }
+
+                if ( empty( $language ) ) {
+                        $queried_id = get_queried_object_id();
+
+                        if ( $queried_id ) {
+                                $language = pll_get_post_language( $queried_id, 'slug' );
+                        }
+                }
+
+                if ( empty( $language ) ) {
+                        $language = UM()->Polylang()->get_current();
+                }
+
+                $default_language = UM()->Polylang()->get_default();
+
+                if ( empty( $language ) || $language === $default_language ) {
+                        return $is_core;
+                }
+
+                $this->sync_current_language_permalinks( $language );
 
                 list( $stored_slug, $default_page_id ) = $this->get_core_page_details( $slug );
 
                 if ( ! $default_page_id ) {
                         return $is_core;
                 }
-                $language        = UM()->Polylang()->get_current();
-                $translated_id   = (int) pll_get_post( $default_page_id, $language );
+
+                $translated_id = (int) pll_get_post( $default_page_id, $language );
 
                 if ( ! $translated_id ) {
                         return $is_core;
@@ -476,8 +500,10 @@ class Permalinks {
          *
          * @since 1.2.3
          */
-        public function sync_current_language_permalinks() {
-                $language = UM()->Polylang()->get_current();
+        public function sync_current_language_permalinks( $language = null ) {
+                if ( empty( $language ) ) {
+                        $language = UM()->Polylang()->get_current();
+                }
 
                 if ( empty( $language ) || $language === $this->synced_language ) {
                         return;

--- a/includes/core/class-permalinks.php
+++ b/includes/core/class-permalinks.php
@@ -502,6 +502,10 @@ class Permalinks {
          */
         public function sync_current_language_permalinks( $language = null ) {
                 if ( empty( $language ) ) {
+                        $language = UM()->Polylang()->get_request_language();
+                }
+
+                if ( empty( $language ) ) {
                         $language = UM()->Polylang()->get_current();
                 }
 

--- a/includes/core/class-permalinks.php
+++ b/includes/core/class-permalinks.php
@@ -15,15 +15,27 @@ defined( 'ABSPATH' ) || exit;
  */
 class Permalinks {
 
-	public $is_switcher = false;
+        public $is_switcher = false;
+
+        /**
+         * Track the language we have already synchronized core pages for.
+         *
+         * @since 1.2.3
+         *
+         * @var string
+         */
+        protected $synced_language = '';
 
 	/**
 	 * Class constructor.
 	 */
-	public function __construct() {
+        public function __construct() {
 
-		// Add rewrite rules for the Account and User page.
-		add_filter( 'rewrite_rules_array', array( &$this, 'add_rewrite_rules' ), 10, 1 );
+                // Keep Ultimate Member core page IDs aligned with the current language.
+                add_action( 'init', array( $this, 'sync_current_language_permalinks' ), 5 );
+
+                // Add rewrite rules for the Account and User page.
+                add_filter( 'rewrite_rules_array', array( &$this, 'add_rewrite_rules' ), 10, 1 );
 
                 // Treat translated Ultimate Member core pages as real core pages.
                 add_filter( 'um_is_core_page', array( $this, 'maybe_recognize_translated_core_page' ), 10, 3 );
@@ -160,25 +172,17 @@ class Permalinks {
                         return $is_core;
                 }
 
-               if ( empty( $slug ) ) {
+                if ( empty( $slug ) ) {
                         return $is_core;
                 }
 
-               $permalinks = UM()->config()->permalinks;
-               $slug_key   = $slug;
+                $this->sync_current_language_permalinks();
 
-               if ( empty( $permalinks[ $slug_key ] ) && false !== strpos( $slug, '-' ) ) {
-                       $normalized = str_replace( '-', '_', $slug );
-                       if ( ! empty( $permalinks[ $normalized ] ) ) {
-                               $slug_key = $normalized;
-                       }
-               }
+                list( $stored_slug, $default_page_id ) = $this->get_core_page_details( $slug );
 
-               if ( empty( $permalinks[ $slug_key ] ) ) {
-                       return $is_core;
-               }
-
-               $default_page_id = (int) $permalinks[ $slug_key ];
+                if ( ! $default_page_id ) {
+                        return $is_core;
+                }
                 $language        = UM()->Polylang()->get_current();
                 $translated_id   = (int) pll_get_post( $default_page_id, $language );
 
@@ -194,11 +198,11 @@ class Permalinks {
                         return $is_core;
                 }
 
-               UM()->config()->permalinks[ $slug_key ] = $translated_id;
+                $this->set_core_page_id( $stored_slug ? $stored_slug : $slug, $translated_id );
 
-               if ( $slug_key !== $slug ) {
-                       UM()->config()->permalinks[ $slug ] = $translated_id;
-               }
+                if ( $stored_slug && $stored_slug !== $slug ) {
+                        $this->set_core_page_id( $slug, $translated_id );
+                }
 
                 return true;
         }
@@ -347,16 +351,23 @@ class Permalinks {
 	 * @param  string $updated Additional parameter 'updated' value.
 	 * @return string
 	 */
-	public function localize_core_page_url( $url, $slug, $updated = '' ) {
-		if ( ! UM()->Polylang()->is_default() ) {
-			$page_id = UM()->config()->permalinks[ $slug ];
-			$url     = $this->get_page_url_for_language( $page_id, UM()->Polylang()->get_current() );
-			if ( $updated ) {
-				$url = add_query_arg( 'updated', esc_attr( $updated ), $url );
-			}
-		}
-		return $url;
-	}
+        public function localize_core_page_url( $url, $slug, $updated = '' ) {
+                if ( ! UM()->Polylang()->is_default() ) {
+                        $page_id = $this->get_core_page_id( $slug );
+
+                        if ( ! $page_id ) {
+                                return $url;
+                        }
+
+                        $url = $this->get_page_url_for_language( $page_id, UM()->Polylang()->get_current() );
+
+                        if ( $updated ) {
+                                $url = add_query_arg( 'updated', esc_attr( $updated ), $url );
+                        }
+                }
+
+                return $url;
+        }
 
 
 	/**
@@ -451,13 +462,145 @@ class Permalinks {
 	 * @param bool   $updated Additional parameter.
 	 * @return string Password reset page URL.
 	 */
-	public function localize_reset_url( $url, $slug, $updated ) {
-		if ( 'password-reset' === $slug && false === $updated ) {
-			if ( ! UM()->Polylang()->is_default() ) {
-				$url = add_query_arg( 'lang', UM()->Polylang()->get_current(), $url );
-			}
-		}
-		return $url;
-	}
+        public function localize_reset_url( $url, $slug, $updated ) {
+                if ( 'password-reset' === $slug && false === $updated ) {
+                        if ( ! UM()->Polylang()->is_default() ) {
+                                $url = add_query_arg( 'lang', UM()->Polylang()->get_current(), $url );
+                        }
+                }
+                return $url;
+        }
+
+        /**
+         * Ensure Ultimate Member's stored core page IDs use the current language translation.
+         *
+         * @since 1.2.3
+         */
+        public function sync_current_language_permalinks() {
+                if ( UM()->Polylang()->is_default() ) {
+                        return;
+                }
+
+                $language = UM()->Polylang()->get_current();
+
+                if ( empty( $language ) || $language === $this->synced_language ) {
+                        return;
+                }
+
+                if ( empty( UM()->config()->permalinks ) || ! is_array( UM()->config()->permalinks ) ) {
+                        return;
+                }
+
+                foreach ( UM()->config()->permalinks as $slug => $page_id ) {
+                        $page_id = (int) $page_id;
+
+                        if ( ! $page_id ) {
+                                continue;
+                        }
+
+                        $translated_id = (int) pll_get_post( $page_id, $language );
+
+                        if ( ! $translated_id ) {
+                                UM()->Polylang()->log_debug(
+                                        'Missing translation for Ultimate Member core page.',
+                                        array(
+                                                'language' => $language,
+                                                'slug'     => $slug,
+                                                'page_id'  => $page_id,
+                                        )
+                                );
+
+                                continue;
+                        }
+
+                        $this->set_core_page_id( $slug, $translated_id );
+
+                        UM()->Polylang()->log_debug(
+                                'Synchronized Ultimate Member core page for language.',
+                                array(
+                                        'language'      => $language,
+                                        'slug'          => $slug,
+                                        'default_page'  => $page_id,
+                                        'translated_id' => $translated_id,
+                                )
+                        );
+                }
+
+                $this->synced_language = $language;
+        }
+
+        /**
+         * Get the current language aware core page ID for a given slug.
+         *
+         * @since 1.2.3
+         *
+         * @param string $slug Core page slug.
+         * @return int
+         */
+        protected function get_core_page_id( $slug ) {
+                list( , $page_id ) = $this->get_core_page_details( $slug );
+
+                return $page_id;
+        }
+
+        /**
+         * Locate the stored permalink entry for a slug.
+         *
+         * @since 1.2.3
+         *
+         * @param string $slug Core page slug.
+         * @return array Array containing the stored slug key and the associated page ID.
+         */
+        protected function get_core_page_details( $slug ) {
+                if ( empty( UM()->config()->permalinks ) || ! is_array( UM()->config()->permalinks ) ) {
+                        return array( '', 0 );
+                }
+
+                if ( isset( UM()->config()->permalinks[ $slug ] ) ) {
+                        return array( $slug, (int) UM()->config()->permalinks[ $slug ] );
+                }
+
+                $alternate = '';
+
+                if ( false !== strpos( $slug, '-' ) ) {
+                        $alternate = str_replace( '-', '_', $slug );
+                } elseif ( false !== strpos( $slug, '_' ) ) {
+                        $alternate = str_replace( '_', '-', $slug );
+                }
+
+                if ( $alternate && isset( UM()->config()->permalinks[ $alternate ] ) ) {
+                        return array( $alternate, (int) UM()->config()->permalinks[ $alternate ] );
+                }
+
+                return array( '', 0 );
+        }
+
+        /**
+         * Store a page ID for both the canonical and alternate representations of a core page slug.
+         *
+         * @since 1.2.3
+         *
+         * @param string $slug    Core page slug key.
+         * @param int    $page_id Page ID to store.
+         */
+        protected function set_core_page_id( $slug, $page_id ) {
+                if ( empty( $slug ) || ! $page_id ) {
+                        return;
+                }
+
+                UM()->config()->permalinks[ $slug ] = (int) $page_id;
+
+                if ( false !== strpos( $slug, '-' ) ) {
+                        $alternate = str_replace( '-', '_', $slug );
+                } elseif ( false !== strpos( $slug, '_' ) ) {
+                        $alternate = str_replace( '_', '-', $slug );
+                } else {
+                        $alternate = '';
+                }
+
+                if ( $alternate ) {
+                        UM()->config()->permalinks[ $alternate ] = (int) $page_id;
+                }
+        }
 
 }

--- a/includes/core/class-permalinks.php
+++ b/includes/core/class-permalinks.php
@@ -160,11 +160,25 @@ class Permalinks {
                         return $is_core;
                 }
 
-                if ( empty( $slug ) || empty( UM()->config()->permalinks[ $slug ] ) ) {
+               if ( empty( $slug ) ) {
                         return $is_core;
                 }
 
-                $default_page_id = (int) UM()->config()->permalinks[ $slug ];
+               $permalinks = UM()->config()->permalinks;
+               $slug_key   = $slug;
+
+               if ( empty( $permalinks[ $slug_key ] ) && false !== strpos( $slug, '-' ) ) {
+                       $normalized = str_replace( '-', '_', $slug );
+                       if ( ! empty( $permalinks[ $normalized ] ) ) {
+                               $slug_key = $normalized;
+                       }
+               }
+
+               if ( empty( $permalinks[ $slug_key ] ) ) {
+                       return $is_core;
+               }
+
+               $default_page_id = (int) $permalinks[ $slug_key ];
                 $language        = UM()->Polylang()->get_current();
                 $translated_id   = (int) pll_get_post( $default_page_id, $language );
 
@@ -180,7 +194,11 @@ class Permalinks {
                         return $is_core;
                 }
 
-                UM()->config()->permalinks[ $slug ] = $translated_id;
+               UM()->config()->permalinks[ $slug_key ] = $translated_id;
+
+               if ( $slug_key !== $slug ) {
+                       UM()->config()->permalinks[ $slug ] = $translated_id;
+               }
 
                 return true;
         }

--- a/includes/front/class-form.php
+++ b/includes/front/class-form.php
@@ -37,7 +37,7 @@ class Form {
 	public function shortcode_atts_ultimatemember( $args ){
 		if ( isset( $args['form_id'] ) ) {
 			$form_id            = absint( $args['form_id'] );
-			$translated_form_id = pll_get_post( $form_id, pll_current_language() );
+                        $translated_form_id = pll_get_post( $form_id, UM()->Polylang()->get_current() );
 
 			if ( $translated_form_id && $translated_form_id !== $form_id ) {
 				$args['form_id'] = $translated_form_id;

--- a/readme.txt
+++ b/readme.txt
@@ -11,7 +11,7 @@ Requires at least: 6.5
 Tested up to: 6.7.1
 Requires UM core at least: 2.6.8
 Tested UM core up to: 2.9.2
-Stable tag: 1.2.2
+Stable tag: 1.2.3
 
 == Description ==
 
@@ -31,7 +31,7 @@ Integrates the "Ultimate Member" plugin with the "Polylang" plugin. Makes UM mul
 == Installation ==
 
 Note: This plugin requires the "Ultimate Member" and "Polylang" plugins to be installed first.
-Note: This plugin is designed to integrate with the "Polylang" plugin, do not use it with the "Polylang PRO" plugin.
+Note: This plugin integrates with both the "Polylang" and "Polylang Pro" plugins.
 
 You can install this plugin from the ZIP file as any other plugin.
 Download ZIP file from GitHub or Google Drive. You can find download links here: https://github.com/umdevelopera/um-polylang
@@ -44,6 +44,12 @@ Open new issue in the GitHub repository if you are facing a problem or have a su
 Documentation is the README section in the GitHub repository: https://github.com/umdevelopera/um-polylang
 
 == Changelog ==
+
+= 1.2.3: February 20, 2025 =
+
+* Enhancements:
+
+        - Added compatibility checks for Polylang Pro so the extension works with either Polylang edition.
 
 = 1.2.2: February 9, 2025 =
 

--- a/um-polylang.php
+++ b/um-polylang.php
@@ -8,11 +8,11 @@
  * Text Domain: um-polylang
  * Domain Path: /languages
  *
- * Requires Plugins: ultimate-member, polylang
+ * Requires Plugins: ultimate-member
  * Requires at least: 6.5
  * Requires PHP: 7.4
  * UM version: 2.9.2
- * Version: 1.2.2
+ * Version: 1.2.3
  *
  * @package um_ext\um_polylang
  */
@@ -31,10 +31,30 @@ define( 'um_polylang_version', $plugin_data['Version'] );
 define( 'um_polylang_textdomain', 'um-polylang' );
 
 
+if ( ! function_exists( 'um_polylang_is_polylang_active' ) ) {
+        /**
+         * Determine if either Polylang (free) or Polylang Pro is active.
+         *
+         * The WordPress plugin dependency header only recognises plugins hosted
+         * on WordPress.org, so Polylang Pro cannot satisfy the dependency
+         * automatically. We therefore perform a manual detection by checking for
+         * the shared helper function and version constants that both editions
+         * expose.
+         *
+         * @since 1.2.3
+         *
+         * @return bool
+         */
+        function um_polylang_is_polylang_active() {
+                return function_exists( 'PLL' ) && ( defined( 'POLYLANG_VERSION' ) || defined( 'POLYLANG_PRO_VERSION' ) );
+        }
+}
+
+
 // Activation script.
 if ( ! function_exists( 'um_polylang_activation_hook' ) ) {
-	function um_polylang_activation_hook() {
-		if ( function_exists( 'UM' ) && function_exists( 'pll_languages_list' ) ) {
+        function um_polylang_activation_hook() {
+                if ( function_exists( 'UM' ) && um_polylang_is_polylang_active() ) {
 			require_once 'includes/admin/class-pll.php';
 			require_once 'includes/core/class-setup.php';
 			if ( class_exists( 'um_ext\um_polylang\core\Setup' ) ) {
@@ -59,15 +79,15 @@ if ( ! function_exists( 'um_polylang_check_dependencies' ) ) {
 					echo '<div class="error"><p>' . wp_kses_post( sprintf( __( 'The <strong>%s</strong> extension requires the Ultimate Member plugin to be activated to work properly. You can download it <a href="https://wordpress.org/plugins/ultimate-member">here</a>', 'um-polylang' ), um_polylang_extension ) ) . '</p></div>';
 				}
 			);
-		} elseif ( ! defined( 'POLYLANG_VERSION' ) ) {
-			// Polylang is not active.
-			add_action(
-				'admin_notices',
-				function () {
-					// translators: %s - plugin name.
-					echo '<div class="error"><p>' . wp_kses_post( sprintf( __( 'The <strong>%s</strong> extension requires the Polylang plugin to be activated to work properly. You can download it <a href="https://wordpress.org/plugins/polylang/">here</a>', 'um-polylang' ), um_polylang_extension ) ) . '</p></div>';
-				}
-			);
+                } elseif ( ! um_polylang_is_polylang_active() ) {
+                        // Polylang (free or pro) is not active.
+                        add_action(
+                                'admin_notices',
+                                function () {
+                                        // translators: %s - plugin name.
+                                        echo '<div class="error"><p>' . wp_kses_post( sprintf( __( 'The <strong>%s</strong> extension requires either the Polylang or Polylang Pro plugin to be activated to work properly.', 'um-polylang' ), um_polylang_extension ) ) . '</p></div>';
+                                }
+                        );
 		} else {
 			require_once 'includes/class-um-polylang.php';
 			UM()->set_class( 'Polylang', true );


### PR DESCRIPTION
## Summary
- add a shared helper to detect either Polylang or Polylang Pro and use it in activation and dependency checks
- refresh compatibility messaging and version metadata to advertise support for Polylang Pro

## Testing
- php -l um-polylang.php
- php -l includes/class-um-polylang.php

------
https://chatgpt.com/codex/tasks/task_e_68daa2c6562c8331affbdbc93191721d