### PR TITLE
Recognize translated core pages in Polylang integration

### DIFF
--- a/includes/core/class-permalinks.php
+++ b/includes/core/class-permalinks.php
@@ -32,6 +32,7 @@ class Permalinks {
 		add_filter( 'um_get_core_page_filter', array( &$this, 'localize_core_page_url' ), 10, 3 );
 		add_filter( 'um_profile_permalink', array( $this, 'localize_profile_permalink' ), 10, 3 );
 		add_filter( 'page_link', array( $this, 'localize_core_page_link' ), 10, 2 );
+		add_filter( 'um_is_core_page', array( $this, 'maybe_flag_translated_core_page' ), 10, 3 );
 
 		// Detect PLL shitcher.
 		add_filter( 'pll_the_languages_args', function( $args ) {
@@ -232,23 +233,69 @@ class Permalinks {
 	}
 
 
-	/**
-	 * Filter account activation link.
-	 * Hook: um_activate_url
-	 *
-	 * @see \um\core\Permalinks
-	 *
-	 * @since 1.1.0
-	 *
-	 * @param string $url Account activation link.
-	 * @return string Localized account activation link.
-	 */
-	public function localize_activate_url( $url ){
-		if ( ! UM()->Polylang()->is_default() ) {
-			$url = add_query_arg( 'lang', UM()->Polylang()->get_current(), $url );
+		/**
+		 * Ensure translated pages are recognised as UM core pages.
+		 *
+		 * @hooked um_is_core_page
+		 *
+		 * @since 1.2.3
+		 *
+		 * @param bool   $is_core_page Whether the page is already considered core.
+		 * @param string $slug         Core page slug being checked.
+		 * @param int    $page_id      Optional page ID supplied by the caller.
+		 * @return bool
+		 */
+		public function maybe_flag_translated_core_page( $is_core_page, $slug, $page_id = 0 ) {
+			if ( $is_core_page || UM()->Polylang()->is_default() ) {
+				return $is_core_page;
+			}
+
+			if ( empty( UM()->config()->permalinks[ $slug ] ) ) {
+				return $is_core_page;
+			}
+
+			$translated_page_id = pll_get_post( UM()->config()->permalinks[ $slug ], UM()->Polylang()->get_current() );
+			if ( ! $translated_page_id ) {
+				return $is_core_page;
+			}
+
+			$queried_id = get_queried_object_id();
+			if ( ! $queried_id && $page_id ) {
+				$queried_id = absint( $page_id );
+			}
+			if ( ! $queried_id ) {
+				$queried_id = absint( get_query_var( 'page_id' ) );
+			}
+			if ( ! $queried_id && isset( $_REQUEST['page_id'] ) ) {
+				$queried_id = absint( wp_unslash( $_REQUEST['page_id'] ) );
+			}
+
+			if ( $queried_id && (int) $translated_page_id === (int) $queried_id ) {
+				UM()->config()->permalinks[ $slug ] = (int) $translated_page_id;
+				return true;
+			}
+
+			return $is_core_page;
 		}
-		return $url;
-	}
+
+
+		/**
+		 * Filter account activation link.
+		 * Hook: um_activate_url
+		 *
+		 * @see \um\core\Permalinks
+		 *
+		 * @since 1.1.0
+		 *
+		 * @param string $url Account activation link.
+		 * @return string Localized account activation link.
+		 */
+		public function localize_activate_url( $url ) {
+			if ( ! UM()->Polylang()->is_default() ) {
+				$url = add_query_arg( 'lang', UM()->Polylang()->get_current(), $url );
+			}
+			return $url;
+		}
 
 
 	/**

--- a/includes/core/class-permalinks.php
+++ b/includes/core/class-permalinks.php
@@ -264,12 +264,19 @@ class Permalinks {
                                return $is_core_page;
                        }
 
+                       $language = pll_get_post_language( $queried_id, 'slug' );
+                       if ( empty( $language ) ) {
+                               $language = UM()->Polylang()->get_current();
+                       }
+                       if ( empty( $language ) ) {
+                               return $is_core_page;
+                       }
+
                        $permalinks = UM()->config()->permalinks;
                        if ( empty( $permalinks ) || ! is_array( $permalinks ) ) {
                                return $is_core_page;
                        }
 
-                       $language   = UM()->Polylang()->get_current();
                        $candidates = array();
 
                        if ( ! empty( $slug ) && isset( $permalinks[ $slug ] ) ) {

--- a/includes/core/class-permalinks.php
+++ b/includes/core/class-permalinks.php
@@ -245,38 +245,57 @@ class Permalinks {
 		 * @param int    $page_id      Optional page ID supplied by the caller.
 		 * @return bool
 		 */
-		public function maybe_flag_translated_core_page( $is_core_page, $slug, $page_id = 0 ) {
-			if ( $is_core_page || UM()->Polylang()->is_default() ) {
-				return $is_core_page;
-			}
+               public function maybe_flag_translated_core_page( $is_core_page, $slug, $page_id = 0 ) {
+                       if ( $is_core_page || UM()->Polylang()->is_default() ) {
+                               return $is_core_page;
+                       }
 
-			if ( empty( UM()->config()->permalinks[ $slug ] ) ) {
-				return $is_core_page;
-			}
+                       $queried_id = get_queried_object_id();
+                       if ( ! $queried_id && $page_id ) {
+                               $queried_id = absint( $page_id );
+                       }
+                       if ( ! $queried_id ) {
+                               $queried_id = absint( get_query_var( 'page_id' ) );
+                       }
+                       if ( ! $queried_id && isset( $_REQUEST['page_id'] ) ) {
+                               $queried_id = absint( wp_unslash( $_REQUEST['page_id'] ) );
+                       }
+                       if ( ! $queried_id ) {
+                               return $is_core_page;
+                       }
 
-			$translated_page_id = pll_get_post( UM()->config()->permalinks[ $slug ], UM()->Polylang()->get_current() );
-			if ( ! $translated_page_id ) {
-				return $is_core_page;
-			}
+                       $permalinks = UM()->config()->permalinks;
+                       if ( empty( $permalinks ) || ! is_array( $permalinks ) ) {
+                               return $is_core_page;
+                       }
 
-			$queried_id = get_queried_object_id();
-			if ( ! $queried_id && $page_id ) {
-				$queried_id = absint( $page_id );
-			}
-			if ( ! $queried_id ) {
-				$queried_id = absint( get_query_var( 'page_id' ) );
-			}
-			if ( ! $queried_id && isset( $_REQUEST['page_id'] ) ) {
-				$queried_id = absint( wp_unslash( $_REQUEST['page_id'] ) );
-			}
+                       $language   = UM()->Polylang()->get_current();
+                       $candidates = array();
 
-			if ( $queried_id && (int) $translated_page_id === (int) $queried_id ) {
-				UM()->config()->permalinks[ $slug ] = (int) $translated_page_id;
-				return true;
-			}
+                       if ( ! empty( $slug ) && isset( $permalinks[ $slug ] ) ) {
+                               $candidates[ $slug ] = (int) $permalinks[ $slug ];
+                       } else {
+                               $candidates = array_map( 'intval', $permalinks );
+                       }
 
-			return $is_core_page;
-		}
+                       foreach ( $candidates as $candidate_slug => $core_page_id ) {
+                               if ( ! $core_page_id ) {
+                                       continue;
+                               }
+
+                               $translated_page_id = pll_get_post( $core_page_id, $language );
+                               if ( ! $translated_page_id ) {
+                                       continue;
+                               }
+
+                               if ( (int) $translated_page_id === (int) $queried_id ) {
+                                       UM()->config()->permalinks[ $candidate_slug ] = (int) $translated_page_id;
+                                       return true;
+                               }
+                       }
+
+                       return $is_core_page;
+               }
 
 
 		/**


### PR DESCRIPTION
## Summary
- hook into `um_is_core_page` so translated core pages can be detected per language
- resolve the current language's page ID and update UM's permalinks map when a translated core page is requested
- keep the account activation helper docblock consistent after adding the new hook

## Testing
- php -l includes/core/class-permalinks.php

------
https://chatgpt.com/codex/tasks/task_e_68dab8720bb88331a1076505f39efcdc